### PR TITLE
feat: add Google OAuth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ Create `./.streamlit/secrets.toml`:
 ```toml
 # ==== Required ====
 OPENAI_API_KEY = "sk-your-key"
-APP_TOKEN = "admin"         # optional gate; if set, the app asks for it in the sidebar
+
+# ==== Auth ====
+GOOGLE_CLIENT_ID = "your-client-id.apps.googleusercontent.com"
+GOOGLE_CLIENT_SECRET = "your-client-secret"
+GOOGLE_REDIRECT_URI = "http://localhost:8501/"  # adjust to your URL
+ALLOWED_EMAILS = ["user@example.com"]          # optional whitelist
 
 # ==== Models ====
 MODEL = "gpt-5-mini"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ openai==1.99.6
 numpy==2.3.2
 streamlit==1.48.0
 pydub==0.25.1
+google-auth-oauthlib==1.2.0


### PR DESCRIPTION
## Summary
- replace token gate with Google OAuth flow using email
- document Google OAuth credentials in README
- add google-auth-oauthlib dependency

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy)*
- `python -m py_compile app/ui/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4ab32fc50832d81a3cbed6af07339