### PR TITLE
feat: add logout for Google auth

### DIFF
--- a/app/services/auth/google_oauth.py
+++ b/app/services/auth/google_oauth.py
@@ -78,7 +78,26 @@ def require_google_auth() -> str:
             include_granted_scopes="true",
             state=signed_state,
         )
-        st.markdown(f"[Login with Google]({auth_url})")
+        button_html = f"""
+        <a href="{auth_url}" target="_self" style="text-decoration:none;">
+            <div style="
+                display:flex;
+                align-items:center;
+                justify-content:center;
+                background-color:white;
+                color:#444;
+                border:1px solid #dadce0;
+                border-radius:4px;
+                padding:0.5em 1em;
+                font-size:16px;
+                font-weight:500;
+                cursor:pointer;">
+                <img src="https://developers.google.com/identity/images/g-logo.png" style="height:18px;margin-right:8px;">
+                <span>Sign in with Google</span>
+            </div>
+        </a>
+        """
+        st.markdown(button_html, unsafe_allow_html=True)
         st.stop()
 
     # 2) Callback: verify state
@@ -111,3 +130,9 @@ def require_google_auth() -> str:
     st.session_state["user_email"] = email
     st.query_params.clear()
     return email
+
+
+def logout() -> None:
+    """Clear stored user session and rerun the app."""
+    st.session_state.pop("user_email", None)
+    st.rerun()

--- a/app/ui/main.py
+++ b/app/ui/main.py
@@ -11,7 +11,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from app.services.auth.google_oauth import require_google_auth
+from app.services.auth.google_oauth import require_google_auth, logout
 from app.services.utils import (
     ensure_dir,
     save_json,
@@ -63,10 +63,13 @@ def pick_language(
     return LANG_PRESETS[choice]
 
 # ---- Google Login (moved to services/auth/google_oauth.py)
-require_google_auth()
+user_email = require_google_auth()
 
 # ---- Sidebar
 st.sidebar.header("Settings")
+st.sidebar.caption(f"Signed in as {user_email}")
+if st.sidebar.button("Log out"):
+    logout()
 DATA_DIR = st.secrets.get("DATA_DIR", "app/data")
 ensure_dir(DATA_DIR)
 


### PR DESCRIPTION
## Summary
- add logout helper to clear session and rerun app
- display signed-in user and logout button in the sidebar

## Testing
- `python -m pytest`
- `python -m py_compile app/services/auth/google_oauth.py app/ui/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5a9325204832d90e1767ac14c0275